### PR TITLE
Revert "Add py3.6"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python
 
 import os
-import sys
 
 from setuptools import Extension, find_packages, setup
 from setuptools.command.build_ext import build_ext
@@ -50,22 +49,10 @@ class CustomBuildExtCommand(build_ext):
 requirements = [
     "numpy", 
     "scipy", 
+    "scikit-learn~=1.1.2", 
     "cython", 
     "six"
     ]
-
-py36_requirements = [
-    'scikit-learn~=0.20.3'
-]
-
-py39_requirements = [
-    'scikit-learn~=1.1.2'
-]
-
-if sys.version_info[0] == 3 and sys.version_info[1] == 6:
-    requirements += py36_requirements
-else:
-    requirements += py39_requirements
 
 if __name__ == "__main__":
     setup(name=DISTNAME,
@@ -84,7 +71,6 @@ if __name__ == "__main__":
               'Intended Audience :: Developers',
               'License :: OSI Approved',
               'Programming Language :: C',
-              'Programming Language :: Python :: 3.6',
               'Programming Language :: Python :: 3.9',
               'Topic :: Software Development',
               'Topic :: Scientific/Engineering',


### PR DESCRIPTION
This reverts commit d339f09d7c39c972c2b20b64fcefad017e695a93.

So it turns out that our py36 version of scikit-garden only works with sklearn>=0.22, which is incompatible with our standard py36 analysis environment that uses sklearn=0.20.3. Although the build passes, it causes build failures in kirby repo, when it tries to import the modules (which have changed). I am reverting the dual compatibility changes to avoid confusion on the master branch.